### PR TITLE
fix(trakt-hook): log errors server-side, quiet token logs

### DIFF
--- a/jellyfin-trakt-hook/src/api/trakt.js
+++ b/jellyfin-trakt-hook/src/api/trakt.js
@@ -6,11 +6,12 @@ const router = express.Router();
 
 const CONFIG_DIR = process.env.CONFIG_DIR;
 const DEBUG_HEADERS = process.env.DEBUG_HEADERS;
+const TRAKT_DEBUG = process.env.TRAKT_DEBUG || false;
 
 let options = {
   client_id: process.env.CLIENT_ID,
   client_secret: process.env.CLIENT_SECRET,
-  debug: process.env.TRAKT_DEBUG || false,
+  debug: TRAKT_DEBUG,
 };
 
 const trakt = new Trakt(options);
@@ -73,10 +74,14 @@ const validateToken = async () => {
   }
 
   if (!TRAKT_TOKEN_IMPORTED) {
-    console.log("[Trakt validateToken] Import token into trakt ...");
+    if (TRAKT_DEBUG) {
+      console.log("[Trakt validateToken] Import token into trakt ...");
+    }
     try {
       const newTokens = await trakt.import_token(CACHED_TOKEN);
-      console.log("[Trakt validateToken] Imported token");
+      if (TRAKT_DEBUG) {
+        console.log("[Trakt validateToken] Imported token");
+      }
 
       if (JSON.stringify(CACHED_TOKEN) !== JSON.stringify(newTokens)) {
         console.log("[Trakt validateToken] Refreshed token");

--- a/jellyfin-trakt-hook/src/middlewares.js
+++ b/jellyfin-trakt-hook/src/middlewares.js
@@ -8,6 +8,7 @@ function notFound(req, res, next) {
 function errorHandler(err, req, res, next) {
   /* eslint-enable no-unused-vars */
   const statusCode = res.statusCode !== 200 ? res.statusCode : 500;
+  console.error(`[errorHandler] ${req.method} ${req.originalUrl} failed:`, err);
   res.status(statusCode);
   res.json({
     message: err.message,


### PR DESCRIPTION
## Problem
`errorHandler` middleware never logged errors to the console — only sent to the response body, which Jellyfin discards. This made all 500s from the trakt hook invisible in logs.

## Changes
- `middlewares.js`: log the error via `console.error` in `errorHandler` before responding.
- `api/trakt.js`: gate the noisy "Import token into trakt ..." / "Imported token" logs behind `TRAKT_DEBUG" (reuses existing env var, no new config needed).

## Testing
- `npx eslint src/api/trakt.js src/middlewares.js` — clean
- `npx jest` — 4/4 passing (with required env vars set)